### PR TITLE
Fix MongoDB start command

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,6 @@
 tasks:
   - init: echo "Replace me with a build script for the project."
-    command: mkdir -p data && mongodb --dbpath data
+    command: mkdir -p /workspace/data && mongod --dbpath /workspace/data
 image:
   file: .gitpod.Dockerfile
 


### PR DESCRIPTION
For some reason, it's `mongod`, not  `mongodb`.

Also, I moved the data directory into `/workspace`, as suggested in https://www.gitpod.io/blog/gitpodify/#mongodb